### PR TITLE
Cleanup test setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.formlib
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 develop-eggs/
 eggs/
 parts/
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,20 @@
 language: python
 sudo: false
 python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - pypy
-# - pypy3
-#   pending 3.3-compatible release
+    - 2.7
+    - 3.3
+    - 3.4
+    - 3.5
+    - pypy
+    - pypy3.5-5.8.0
 install:
-  - pip install tox-travis
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-  - tox
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
 
 recursive-include src *
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(name='zope.formlib',
       extras_require=dict(
           test=['zope.configuration',
                 'zope.testing',
+                'zope.testrunner',
                ]
           ),
       install_requires=[

--- a/tox.ini
+++ b/tox.ini
@@ -6,22 +6,6 @@ envlist =
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src
 deps =
-    pytz
-    zope.browser
-    zope.browserpage
-    zope.component
-    zope.event
-    zope.i18n
-    zope.i18nmessageid
-    zope.interface
-    zope.lifecycleevent
-    zope.publisher
-    zope.schema
-    zope.security
-    zope.traversing
-    zope.datetime
-    zope.configuration
-    zope.testing
-    zope.testrunner
+    .[test]


### PR DESCRIPTION
We cannot run the tests via `setup.py` anymore as there is a namespace problem. So I changed it to the style currently used in other projects.