### PR TITLE
Make the tests compatible with zope.i18n >= 4.5.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make the tests compatible with ``zope.i18n >= 4.5``.
 
 
 4.5.0 (2018-09-27)

--- a/src/zope/formlib/tests/test_formlib.py
+++ b/src/zope/formlib/tests/test_formlib.py
@@ -273,7 +273,8 @@ translation domain.  We'll create one for our needs:
     ... class MyDomain:
     ...
     ...     def translate(self, msgid, mapping=None, context=None,
-    ...                   target_language=None, default=None):
+    ...                   target_language=None, default=None,
+    ...                   msgid_plural=None, default_plural=None, number=None):
     ...         print(msgid)
     ...         print(mapping)
     ...         print(context)

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,9 @@ envlist =
 [testenv]
 commands =
     zope-testrunner --test-path=src
-deps =
-    .[test]
+extras = test
 
 [testenv:docs]
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-deps =
-    .[docs]
+extras = docs


### PR DESCRIPTION
Fixes #22.