### PR TITLE
Ensure consistent resolution orders

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,9 @@ exclude_lines =
     raise NotImplementedError
     self.fail
     raise AssertionError
+
+[paths]
+source =
+    src/
+    .tox/*/lib/python*/site-packages/
+    .tox/pypy*/site-packages/

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ parts/
 coverage/
 .coverage
 htmlcov/
+coverage.xml
 docs/_build/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@
 4.7.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Ensure all objects have consistent interface resolution orders.
+  See `issue 30
+  <https://github.com/zopefoundation/zope.formlib/issues/30>`_.
 
+- Remove support for deprecated ``python setup.py test`` command.
 
 4.7.0 (2020-02-27)
 ==================
@@ -78,7 +81,7 @@
 4.2.1 (2013-02-22)
 ==================
 
-- Moved default values for the `BooleanDisplayWidget` from module to class
+- Moved default values for the ``BooleanDisplayWidget`` from module to class
   definition to make them changeable in instance.
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,21 +25,6 @@ def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-def alltests():
-    import os
-    import sys
-    import unittest
-    # use the zope.testrunner machinery to find all the
-    # test suites we've put under ourselves
-    import zope.testrunner.find
-    import zope.testrunner.options
-    here = os.path.abspath(os.path.join(os.path.dirname(__file__), 'src'))
-    args = sys.argv[:]
-    defaults = ["--test-path", here]
-    options = zope.testrunner.options.get_options(args, defaults)
-    suites = list(zope.testrunner.find.find_suites(options))
-    return unittest.TestSuite(suites)
-
 setup(name='zope.formlib',
       version='4.7.1.dev0',
       author='Zope Foundation and Contributors',
@@ -111,7 +96,14 @@ setup(name='zope.formlib',
           'zope.testing',
           'zope.testrunner',
       ],
-      test_suite='__main__.alltests',
       include_package_data=True,
       zip_safe=False,
+      python_requires=', '.join([
+          '>=2.7',
+          '!=3.0.*',
+          '!=3.1.*',
+          '!=3.2.*',
+          '!=3.3.*',
+          '!=3.4.*',
+      ]),
 )

--- a/src/zope/formlib/errors.py
+++ b/src/zope/formlib/errors.py
@@ -53,7 +53,7 @@ class InvalidErrorView(object):
         return u'<span class="error">%s</span>' % escape(msg)
 
 
-@implementer(IBrowserPage)
+
 @adapter(IInvalidCSRFTokenError, IBrowserRequest)
 class InvalidCSRFTokenErrorView(BrowserPage):
 

--- a/src/zope/formlib/itemswidgets.py
+++ b/src/zope/formlib/itemswidgets.py
@@ -17,7 +17,6 @@ __docformat__ = 'restructuredtext'
 from xml.sax.saxutils import escape
 
 from zope import component
-from zope.interface import implementer
 from zope.i18n import translate
 from zope.schema.interfaces import InvalidValue
 from zope.schema.interfaces import ITitledTokenizedTerm
@@ -299,7 +298,7 @@ class SetDisplayWidget(ItemsMultiDisplayWidget):
 EXPLICIT_EMPTY_SELECTION = True
 
 
-@implementer(IInputWidget)
+
 class ItemsEditWidgetBase(SingleDataHelper, ItemsWidgetBase):
     """Widget Base for rendering item-related fields.
 
@@ -628,4 +627,3 @@ class MultiCheckBoxWidget(ItemsMultiEditWidgetBase):
         return renderElement(u'label',
                              contents=contents,
                              **{'for': id})
-

--- a/src/zope/formlib/tests/test_displaywidget.py
+++ b/src/zope/formlib/tests/test_displaywidget.py
@@ -30,18 +30,20 @@ def test_implemented_interfaces():
     `IBrowserWidget`.
 
     >>> from zope.formlib.interfaces import IBrowserWidget
+    >>> from zope.interface import implementedBy
+    >>> from zope.interface.verify import verifyClass
+    >>> IBrowserWidget in implementedBy(DisplayWidget)
+    True
     >>> verifyClass(IBrowserWidget, DisplayWidget)
     True
 
     But unlike most other widgets in this package, the display widget is *not*
     an `IInputWidget`.
 
+
     >>> from zope.formlib.interfaces import IInputWidget
-    >>> try:
-    ...     verifyClass(IInputWidget, DisplayWidget)
-    ... except DoesNotImplement:
-    ...     'not implemented'
-    'not implemented'
+    >>> IInputWidget in implementedBy(DisplayWidget)
+    False
     """
 
 def test_not_required():

--- a/src/zope/formlib/textwidgets.py
+++ b/src/zope/formlib/textwidgets.py
@@ -536,7 +536,6 @@ class IntWidget(TextWidget):
                 raise ConversionError(_("Invalid integer data"), v)
 
 
-@implementer(IInputWidget)
 class FloatWidget(TextWidget):
     displayWidth = 10
 
@@ -549,7 +548,7 @@ class FloatWidget(TextWidget):
             except ValueError as v:
                 raise ConversionError(_("Invalid floating point data"), v)
 
-@implementer(IInputWidget)
+
 class DecimalWidget(TextWidget):
     displayWidth = 10
 

--- a/src/zope/formlib/widget.py
+++ b/src/zope/formlib/widget.py
@@ -15,16 +15,17 @@
 """
 __docformat__ = 'restructuredtext'
 
+import warnings
 from xml.sax.saxutils import quoteattr, escape
 
-from zope.component import getMultiAdapter, provideAdapter
+from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.schema.interfaces import ValidationError
 from zope.publisher.browser import BrowserView
-from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 from zope.formlib.interfaces import ConversionError
 from zope.formlib.interfaces import WidgetInputError, MissingInputError
+from zope.formlib.interfaces import IInputWidget
 from zope.formlib.interfaces import IBrowserWidget
 from zope.formlib.interfaces import ISimpleInputWidget
 from zope.formlib.interfaces import IWidgetInputErrorView
@@ -33,8 +34,6 @@ from zope.formlib._compat import toUnicode
 
 from zope.i18n import translate
 from zope.schema.interfaces import IChoice, ICollection
-
-import warnings
 
 
 if quoteattr("\r") != '"&13;"':
@@ -167,6 +166,8 @@ class BrowserWidget(Widget, BrowserView):
     view that is registered as providing `IWidgetInputErrorView`. To
     illustrate, we can create and register a simple error display view:
 
+        >>> from zope.component import provideAdapter
+        >>> from zope.publisher.interfaces.browser import IDefaultBrowserLayer
         >>> from zope.formlib.interfaces import IWidgetInputError
         >>> @implementer(IWidgetInputErrorView)
         ... class SnippetErrorView:
@@ -533,6 +534,7 @@ class SimpleInputWidget(BrowserWidget, InputWidget):
                              value=self._getFormValue(),
                              cssClass=self.cssClass,
                              extra=self.extra)
+
 
 class DisplayWidget(BrowserWidget):
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ extras =
 deps =
     coverage
 setenv =
-     ZOPE_INTERFACE_STRICT_IRO=1
+    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,36 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,py38,pypy,pypy3,docs
+    py27,py35,py36,py37,py38,pypy,pypy3,coverage,docs
+# Note: if you add new Python versions, please add them to
+# [testenv:coverage] depends as well!
 
 [testenv]
 commands =
-    zope-testrunner --test-path=src
-extras = test
+    coverage run -p -m zope.testrunner --test-path=src []
+extras =
+    test
+deps =
+    coverage
+setenv =
+     ZOPE_INTERFACE_STRICT_IRO=1
+
+[testenv:coverage]
+skip_install = true
+commands =
+    coverage erase
+    coverage combine
+    coverage html -i
+    coverage xml -i
+    coverage report --fail-under=94 --show-missing
+# parallel mode: make sure all builds complete before we run this one
+depends =
+    py27,py35,py36,py37,py38,pypy,pypy3
+parallel_show_output = true
 
 [testenv:docs]
+basepython =
+    python3
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
-extras = docs
+extras =
+    docs


### PR DESCRIPTION
Remove support for setup.py test, and add `python_requires` metadata.

Fixes #30