### PR TITLE
Fix checking of constraints on field contents.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,11 @@
 5.0.0 (unreleased)
 ==================
 
-Breaking changes
-----------------
+Possibly breaking changes
+-------------------------
 
-- Fix checking of constraints on field contents. This requires the default
-  prefix of an ``IFormField`` to be non-empty. It now defaults to
-  ``form_field``.
+- Fix checking of constraints on field contents. The ``prefix`` of an
+  ``IFormField`` can still be empty and now officially allows dots.
 
 Features
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,23 @@
  Changes
 =========
 
-4.8.0 (unreleased)
+5.0.0 (unreleased)
 ==================
 
+Breaking changes
+----------------
+
+- Fix checking of constraints on field contents. This requires the default
+  prefix of an ``IFormField`` to be non-empty. It now defaults to
+  ``form_field``.
+
+Features
+--------
+
 - Add support for Python 3.9.
+
+Other changes
+-------------
 
 - Remove unused non-BBB imports.
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(*rnames):
 
 
 setup(name='zope.formlib',
-      version='4.8.0.dev0',
+      version='5.0.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Form generation and validation library for Zope',

--- a/src/zope/formlib/interfaces.py
+++ b/src/zope/formlib/interfaces.py
@@ -328,17 +328,15 @@ class ITextBrowserWidget(ISimpleInputWidget):
             u'If True, an empty string is converted to field.missing_value.'),
         default=True)
 
-# XXX this seems to be buggy (since at least 2005)
-# it returns None, and prefix_re is never defined.
-
 
 def reConstraint(pat, explanation):
     pat = re.compile(pat)
 
     def constraint(value):
-        if prefix_re.match(value):  # noqa: F821 undefined name
+        if pat.match(value):
             return True
         raise Invalid(value, explanation)
+    return constraint
 
 
 class IWidgetInputErrorView(Interface):
@@ -878,7 +876,7 @@ class IFormField(Interface):
         disambiguate fields with the same name (e.g. from different
         schema) within a collection of form fields.
         """,
-        default="",
+        default="form_field",
     )
 
     for_display = schema.Bool(

--- a/src/zope/formlib/interfaces.py
+++ b/src/zope/formlib/interfaces.py
@@ -329,10 +329,12 @@ class ITextBrowserWidget(ISimpleInputWidget):
         default=True)
 
 
-def reConstraint(pat, explanation):
+def reConstraint(pat, explanation, can_be_empty=False):
     pat = re.compile(pat)
 
     def constraint(value):
+        if not value and can_be_empty:
+            return True
         if pat.match(value):
             return True
         raise Invalid(value, explanation)
@@ -868,15 +870,17 @@ class IFormField(Interface):
     )
 
     prefix = schema.ASCII(
-        constraint=reConstraint('[a-zA-Z][a-zA-Z0-9_]*',
-                                "Must be an identifier"),
+        constraint=reConstraint(
+            r'[a-zA-Z][a-zA-Z0-9_\.]*', "Must be an identifier or empty",
+            can_be_empty=True),
         title=u"Prefix",
         description=u"""\
         Form-field prefix.  The form-field prefix is used to
         disambiguate fields with the same name (e.g. from different
         schema) within a collection of form fields.
         """,
-        default="form_field",
+        required=False,
+        default="",
     )
 
     for_display = schema.Bool(

--- a/src/zope/formlib/interfaces.py
+++ b/src/zope/formlib/interfaces.py
@@ -871,7 +871,7 @@ class IFormField(Interface):
 
     prefix = schema.ASCII(
         constraint=reConstraint(
-            r'[a-zA-Z][a-zA-Z0-9_\.]*', "Must be an identifier or empty",
+            r'[a-zA-Z][a-zA-Z0-9_.]*', "Must be an identifier or empty",
             can_be_empty=True),
         title=u"Prefix",
         description=u"""\

--- a/src/zope/formlib/tests/test_interfaces.py
+++ b/src/zope/formlib/tests/test_interfaces.py
@@ -1,0 +1,34 @@
+from .. interfaces import reConstraint
+import unittest
+import zope.interface
+
+
+class TestReConstraint(unittest.TestCase):
+    """Testing ..interfaces.reConstraint()."""
+
+    def test__interfaces__reConstraint__1(self):
+        """It returns a function returning True if the pattern is matched."""
+        func = reConstraint('^[A-Z]+$', 'only capital letters allowed')
+        self.assertTrue(func('ABC'))
+
+    def test__interfaces__reConstraint__2(self):
+        """It returns a function raising Invalid if pattern is not matched."""
+        func = reConstraint('^[A-Z]+$', 'only capital letters allowed')
+        with self.assertRaises(zope.interface.Invalid) as err:
+            func('ABc')
+        self.assertEqual(
+            "('ABc', 'only capital letters allowed')", str(err.exception))
+
+    def test__interfaces__reConstraint__3(self):
+        """It returns a function raising Invalid for empty values."""
+        func = reConstraint('^[A-Z]+$', 'only capital letters allowed')
+        with self.assertRaises(zope.interface.Invalid) as err:
+            func('')
+        self.assertEqual(
+            "('', 'only capital letters allowed')", str(err.exception))
+
+    def test__interfaces__reConstraint__4(self):
+        """It returns a function allowing empty values if configured."""
+        func = reConstraint(
+            '^[A-Z]+$', 'only capital letters or empty', can_be_empty=True)
+        self.assertTrue(func(''))


### PR DESCRIPTION
This requires the default prefix of an ``IFormField`` to be non-empty.
It now defaults to ``form_field``.