### PR TITLE
Fix generating documentation.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,17 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
     strategy:
+      # We want do see all failures:
+      fail-fast: false
       matrix:
         config:
         # [Python version, tox env]

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 [meta]
 template = "pure-python"
-commit-id = "9eb3f8c0509c4389a028555a80d8c1aa7a80a030"
+commit-id = "f8468b0bc5c92479b3043372d89cf5852176015d"
 
 [python]
 with-appveyor = false
@@ -31,10 +31,14 @@ testenv-additional = [
     "setenv =",
     "    ZOPE_INTERFACE_STRICT_IRO=1",
     ]
+use-flake8 = true
 
 [manifest]
 additional-rules = [
     "recursive-include src *.js",
+    "recursive-include src *.pt",
+    "recursive-include src *.rst",
+    "recursive-include src *.zcml",
     ]
 
 [check-manifest]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,15 +5,13 @@ include *.txt
 include buildout.cfg
 include tox.ini
 
-recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst
 recursive-include docs *.txt
 recursive-include docs Makefile
 
-recursive-include src *.pt
 recursive-include src *.py
-recursive-include src *.rst
-recursive-include src *.txt
-recursive-include src *.zcml
 recursive-include src *.js
+recursive-include src *.pt
+recursive-include src *.rst
+recursive-include src *.zcml

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
  zope.formlib
 ==============
 
-.. image:: https://travis-ci.com/zopefoundation/zope.formlib.svg?branch=master
-        :target: https://travis-ci.com/zopefoundation/zope.formlib
+.. image:: https://github.com/zopefoundation/zope.formlib/actions/workflows/tests.yml/badge.svg
+        :target: https://github.com/zopefoundation/zope.formlib/actions/workflows/tests.yml
 
 .. image:: https://readthedocs.org/projects/zopeformlib/badge/?version=latest
         :target: https://zopeformlib.readthedocs.io/en/latest/

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,8 @@ commands =
 [testenv:docs]
 basepython = python3
 skip_install = false
-deps =
+# Until repoze.sphinx.autointerface supports Sphinx 4.x we cannot use it:
+deps = Sphinx < 4
 extras =
     docs
 commands_pre =


### PR DESCRIPTION
Use `Sphinx < 4` to prevent problems with `repoze.sphinx.autointerface`.