### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-6.2 (unreleased)
+7.0 (unreleased)
 ================
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 7.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read(*rnames):
 
 
 setup(name='zope.formlib',
-      version='6.2.dev0',
+      version='7.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Form generation and validation library for Zope',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -61,15 +60,12 @@ setup(name='zope.formlib',
           'Framework :: Zope :: 3',
       ],
       url='https://github.com/zopefoundation/zope.formlib',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       extras_require={
           'test': [
               'zope.configuration',
               'zope.schema >= 6.1',
               'zope.testing',
-              'zope.testrunner',
+              'zope.testrunner >= 6.4',
           ],
           'docs': [
               'Sphinx',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
